### PR TITLE
Add extensive tests for regex engine and search functions

### DIFF
--- a/re_test.go
+++ b/re_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func TestRegexMatchFeatures(t *testing.T) {
+	tests := []struct {
+		pattern string
+		text    string
+		want    bool
+	}{
+		{"a", "a", true},
+		{"a", "b", false},
+		{"^hello", "hello world", true},
+		{"^hello", "a hello", false},
+		{"world$", "hello world", true},
+		{"^hello$", "hello", true},
+		{"^hello$", "hello world", false},
+		{"h.llo", "hallo", true},
+		{"h.llo", "hllo", false},
+		{"[abc]+", "cab", true},
+		{"[^abc]+", "def", true},
+		{"a+b", "aaab", true},
+		{"a+b", "b", false},
+		{"ab?c", "abc", true},
+		{"ab?c", "ac", true},
+		{"ab?c", "abbc", false},
+		{"(ab)+c", "ababc", true},
+		{"(ab)+c", "aba", false},
+		{"(ab)\\1", "abab", true},
+		{"(ab)\\1", "abac", false},
+		{"a|b", "b", true},
+		{"a|b", "c", false},
+		{"\\d+", "12345", true},
+		{"\\w+", "abc_123", true},
+		{"", "anything", true},
+	}
+
+	for _, tt := range tests {
+		re, err := Compile(tt.pattern)
+		if err != nil {
+			t.Fatalf("Compile(%q) error: %v", tt.pattern, err)
+		}
+		got, err := re.Match([]byte(tt.text))
+		if err != nil {
+			t.Fatalf("Match(%q, %q) error: %v", tt.pattern, tt.text, err)
+		}
+		if got != tt.want {
+			t.Errorf("Match(%q, %q) = %v, want %v", tt.pattern, tt.text, got, tt.want)
+		}
+	}
+}
+
+func TestRegexAnchors(t *testing.T) {
+	re, err := Compile("^foo$")
+	if err != nil {
+		t.Fatalf("Compile error: %v", err)
+	}
+	if ok, _ := re.Match([]byte("foo")); !ok {
+		t.Fatalf("expected exact match")
+	}
+	if ok, _ := re.Match([]byte("foobar")); ok {
+		t.Fatalf("unexpected match for prefix")
+	}
+}

--- a/search_test.go
+++ b/search_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestParseArgs(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"mygrep", "-r", "-E", "pattern", "file1", "file2"}
+	args := parseArgs()
+	if !args.Recursive || args.Pattern != "pattern" || len(args.Paths) != 2 || args.Paths[0] != "file1" || args.Paths[1] != "file2" {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+	return buf.String()
+}
+
+func TestGrepStdin(t *testing.T) {
+	re, _ := Compile("foo")
+	inR, inW, _ := os.Pipe()
+	oldIn := os.Stdin
+	os.Stdin = inR
+	go func() {
+		defer inW.Close()
+		inW.WriteString("bar\nfoo\n")
+	}()
+	out := captureOutput(func() {
+		if !grepStdin(re) {
+			t.Fatalf("expected match")
+		}
+	})
+	os.Stdin = oldIn
+	if strings.TrimSpace(out) != "foo" {
+		t.Fatalf("unexpected output %q", out)
+	}
+}
+
+func TestGrepFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "test.txt")
+	os.WriteFile(file, []byte("hello\nfoo\nbar\n"), 0644)
+	re, _ := Compile("foo")
+	out := captureOutput(func() {
+		if !grepFile(re, file, false) {
+			t.Fatalf("expected match")
+		}
+	})
+	if strings.TrimSpace(out) != "foo" {
+		t.Fatalf("unexpected output %q", out)
+	}
+	out2 := captureOutput(func() {
+		if !grepFile(re, file, true) {
+			t.Fatalf("expected match")
+		}
+	})
+	expected := file + ":foo"
+	if strings.TrimSpace(out2) != expected {
+		t.Fatalf("unexpected output with prefix %q", out2)
+	}
+}
+
+func TestGrepRecursive(t *testing.T) {
+	root := t.TempDir()
+	f1 := filepath.Join(root, "f1.txt")
+	os.WriteFile(f1, []byte("foo\n"), 0644)
+	sub := filepath.Join(root, "sub")
+	os.Mkdir(sub, 0755)
+	f2 := filepath.Join(sub, "f2.txt")
+	os.WriteFile(f2, []byte("bar\nfoo\n"), 0644)
+	re, _ := Compile("foo")
+	out := captureOutput(func() {
+		if !grepRecursive(re, root, true) {
+			t.Fatalf("expected match")
+		}
+	})
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), out)
+	}
+	expected1 := f1 + ":foo"
+	expected2 := f2 + ":foo"
+	sort.Strings(lines)
+	if lines[0] != expected1 || lines[1] != expected2 {
+		t.Fatalf("unexpected lines %v", lines)
+	}
+}


### PR DESCRIPTION
## Summary
- Add table-driven tests covering regex features like anchors, quantifiers, groups, alternation, and escapes
- Exercise argument parsing, stdin/file search, and recursive directory traversal

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_68ab837045c883318a495fa74e6c2270